### PR TITLE
Rollback artifact versioning controlled by props

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ibm</groupId>
-  <artifactId>sparkoscope-headless_${spark.version}_${scala.version.short}</artifactId>
+  <artifactId>sparkoscope-headless</artifactId>
   <packaging>pom</packaging>
   <version>0.1.0</version>
 

--- a/sparkoscope-hdfssink/pom.xml
+++ b/sparkoscope-hdfssink/pom.xml
@@ -3,13 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>sparkoscope-headless_${spark.version}_${scala.version.short}</artifactId>
+        <artifactId>sparkoscope-headless</artifactId>
         <groupId>com.ibm</groupId>
         <version>0.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>sparkoscope-hdfssink_${spark.version}_${scala.version.short}</artifactId>
+    <artifactId>sparkoscope-hdfssink</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/sparkoscope-sigarsource/pom.xml
+++ b/sparkoscope-sigarsource/pom.xml
@@ -3,13 +3,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>sparkoscope-headless_${spark.version}_${scala.version.short}</artifactId>
+        <artifactId>sparkoscope-headless</artifactId>
         <groupId>com.ibm</groupId>
         <version>0.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>sparkoscope-sigarsource_${spark.version}_${scala.version.short}</artifactId>
+    <artifactId>sparkoscope-sigarsource</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Maven does not officially support variable substitution in artifact's or parent's name/verison.
The cross-build approach which was taken in #1 caused maven to corrupt pom.xml of the resulting
artifact rendering it not usable.

This commit rolls back an attempt to change artifact name by using properties