### PR TITLE
Add conversion from CPU "ticks" to percents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.ibm</groupId>
   <artifactId>sparkoscope-headless</artifactId>
   <packaging>pom</packaging>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
 
   <properties>
     <spark.version>1.6.2</spark.version>

--- a/sparkoscope-hdfssink/pom.xml
+++ b/sparkoscope-hdfssink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sparkoscope-headless</artifactId>
         <groupId>com.ibm</groupId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sparkoscope-sigarsource/pom.xml
+++ b/sparkoscope-sigarsource/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sparkoscope-headless</artifactId>
         <groupId>com.ibm</groupId>
-        <version>0.1.1</version>
+        <version>0.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Sigar API returns CPU metrics in ticks that should be converted to average percentage per time window